### PR TITLE
Add LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,11 @@
+Coding Challenge License
+
+Copyright © CFP FlexPower 2025
+
+Permission is hereby granted to any individual receiving this challenge ("the Candidate") to use, reproduce, and modify the materials provided herein (the "Challenge") solely for the purpose of completing and submitting a response to CFP FlexPower as part of a hiring or evaluation process.
+
+The Candidate may not use the Challenge or any derivative works for commercial purposes or distribute them publicly without prior written permission from CFP FlexPower.
+
+CFP FlexPower retains all rights, title, and interest in and to the Challenge. Any submission by the Candidate shall remain the intellectual property of the Candidate; however, the Candidate grants CFP FlexPower a non-exclusive, royalty-free license to use, review, and evaluate such submission for hiring or evaluation purposes.
+
+THE CHALLENGE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND


### PR DESCRIPTION
## Summary
- Add LICENSE.md file with the standard CFP FlexPower challenge license

This license file clarifies the terms under which candidates can use and modify the challenge materials.